### PR TITLE
Change relative README link to an absolute one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shippy
 
-This is the codebase for the multi-part series on writing microservices in Golang [found here](ewanvalentine.io).
+This is the codebase for the multi-part series on writing microservices in Golang [found here](https://ewanvalentine.io/).
 
 
 ## Table of contents (this may change as the series progresses).


### PR DESCRIPTION
Hey, I've noticed that the link in the README points to:

https://github.com/EwanValentine/shippy/blob/master/ewanvalentine.io

Great work on the tutorials so far! Keep fighting the good fight! :-)