### PR TITLE
Upgraded go 1.9 to 1.11 (fix for miekg/dns)

### DIFF
--- a/consignment-service/Dockerfile
+++ b/consignment-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.0 as builder
+FROM golang:1.11.0 as builder
 
 WORKDIR /go/src/github.com/EwanValentine/shippy/consignment-service
 


### PR DESCRIPTION
It fixes this error:

```
# github.com/EwanValentine/shippy/consignment-service/vendor/github.com/miekg/dns
vendor/github.com/miekg/dns/dnssec_keyscan.go:290:7: undefined: strings.Builder
vendor/github.com/miekg/dns/msg_helpers.go:271:8: undefined: strings.Builder
vendor/github.com/miekg/dns/serve_mux.go:43:9: undefined: strings.Builder
vendor/github.com/miekg/dns/types.go:440:10: undefined: strings.Builder
vendor/github.com/miekg/dns/types.go:464:10: undefined: strings.Builder
vendor/github.com/miekg/dns/types.go:492:10: undefined: strings.Builder
vendor/github.com/miekg/dns/types.go:513:29: undefined: strings.Builder
vendor/github.com/miekg/dns/types.go:523:28: undefined: strings.Builder
```