### PR TITLE
sync the change of go-micro

### DIFF
--- a/consignment-cli/cli.go
+++ b/consignment-cli/cli.go
@@ -8,7 +8,7 @@ import (
 
 	pb "github.com/EwanValentine/shippy/consignment-service/proto/consignment"
 	microclient "github.com/micro/go-micro/client"
-	"github.com/micro/go-micro/cmd"
+	"github.com/micro/go-micro/config/cmd"
 	"github.com/micro/go-micro/metadata"
 	"golang.org/x/net/context"
 )


### PR DESCRIPTION
`cmd` has moved to `config/cmd` on 21 Jun.

Please check this [commit](https://github.com/micro/go-micro/commit/c350e19552d36c71c9051189267b0a10842e2c61) of  go-micro.Other branch may need this change together.
